### PR TITLE
Fix Pac-Man maze boundary bug

### DIFF
--- a/pyman.py
+++ b/pyman.py
@@ -78,12 +78,13 @@ def draw_maze():
 
 def move_pacman():
     global pacman_pos, score
-    new_x = pacman_pos[0] + direction[0]
+    cols = len(maze[0])
+    new_x = (pacman_pos[0] + direction[0]) % cols
     new_y = pacman_pos[1] + direction[1]
-    if maze[new_y][new_x] not in '#':
+    if 0 <= new_y < len(maze) and maze[new_y][new_x] != '#':
         pacman_pos = [new_x, new_y]
         tile = maze[new_y][new_x]
-        if tile == '.' or tile == 'o':
+        if tile in '.o':
             row = list(maze[new_y])
             row[new_x] = ' '
             maze[new_y] = ''.join(row)
@@ -157,4 +158,6 @@ def main():
 
         pygame.display.update()
 
-main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure Pac-Man wraps around horizontally and stays within maze bounds
- guard main entry point for safer importing

## Testing
- `python -m compileall .`
- `python - <<'PY'
import pyman
pyman.pacman_pos=[0,10]
pyman.direction=[-1,0]
for i in range(35):
    pyman.move_pacman()
print('final', pyman.pacman_pos)
PY`


------

## Summary by Sourcery

Fix maze boundary logic to allow horizontal wrapping and prevent out-of-bounds vertical movement; add main entry guard.

Bug Fixes:
- Wrap Pac-Man horizontally at maze edges using modulo arithmetic
- Prevent vertical out-of-bounds moves by checking new_y against maze height

Enhancements:
- Simplify pellet detection using in operator for tiles

Chores:
- Add __name__ guard around main() to support safe importing